### PR TITLE
Add rgb-primary-text-color to fix missing Hover effect (#19)

### DIFF
--- a/themes/blue_night.yaml
+++ b/themes/blue_night.yaml
@@ -76,6 +76,7 @@ blue_night:
   primary-background-color: "hsl(var(--huesat) 16%)"
   primary-color: "#2581ab"
   primary-text-color: "hsl(var(--huesat) 90%)"
+  rgb-primary-text-color: "0, 120 , 160"
   secondary-background-color: "hsl(var(--huesat) 16%)"
   secondary-text-color: "hsl(var(--huesat) 80%)"
   shadow-elevation-16dp_-_box-shadow: "0px 0px 0px 0px hsl(var(--huesat) 25%)"
@@ -86,3 +87,4 @@ blue_night:
   table-row-alternative-background-color: "hsl(var(--huesat) 10%)"
   table-row-background-color: "hsl(var(--huesat) 12%)"
   text-primary-color: "hsl(var(--huesat) 90%)"
+


### PR DESCRIPTION
* Add rgb-primary-text-color to fix missing Hover effect

Add rgb-primary-text-color to fix missing Hover effect

* Alphabetical reordering

Place the new line `rgb-primary-text-color: "0, 120 , 160"` in the correct place alphabetically